### PR TITLE
Fixed issue with encode_many

### DIFF
--- a/mapchiral/mapchiral.py
+++ b/mapchiral/mapchiral.py
@@ -425,7 +425,7 @@ def encode_many(mols, max_radius:int=2, n_permutations:int=2048, mapping:bool=Fa
     if mapping:
         return get_fingerprints_with_mapping(mols, max_radius, n_permutations, n_cpus, seed)
     else:
-        return get_fingerprints(mols, max_radius, n_cpus, n_permutations)
+        return get_fingerprints(mols, max_radius, n_permutations, n_cpus)
 
 
 def jaccard_similarity(fingerprint_1:np.array=None, fingerprint_2:np.array=None):


### PR DESCRIPTION
Hi!

I found out that the function `encode_many` takes the number of CPUs as the number of permutations and vice versa. That happens because variables are passed in the wrong way, given the original order in the function`get_fingerprints`:

```
def get_fingerprints(mols:list, max_radius:int=2, n_permutations:int=2048, n_cpus:int=4) -> list:

def encode_many(mols, max_radius:int=2, n_permutations:int=2048, mapping:bool=False, n_cpus:int=4, seed:int=42)
<....>
return get_fingerprints(mols, max_radius, n_cpus, n_permutations)

```